### PR TITLE
Some doc updates for getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plug 'w0rp/ale'
 Plug 'skaji/syntax-check-perl'
 call plug#end()
 
-let g:ale_linters = { 'perl': ['syntax_check'] }
+let g:ale_linters = { 'perl': ['syntax-check'] }
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ let g:ale_perl_syntax_check_config = g:plug_home . '/syntax-check-perl/config/re
 
 The config files are written in Perl, so you can do whatever you want:) See [default.pl](config/default.pl).
 
+## Debugging
+
+You can use `:ALEInfo` in `vim` to troubleshoot `Ale` plugins.  For instance,
+if the path to `ale_perl_syntax_check_config` does not exist, the plugin may
+fail silently.  Scroll to the bottom of the `:ALEInfo` output to find any
+errors which may have been produced by this plugin.
+
 ## Author
 
 Shoichi Kaji


### PR DESCRIPTION
Thanks so much for this.  It took me a bit to get up and running because initially everything was just failing silently.  I eventually found that I was using the wrong linter name and I was using a path to the config file which didn't exist.  The fact that there are no hints about the config file being missing was pretty confusing.  I don't know the best way to handle this.  It might be confusing to continue on without having a config file if the user has supplied a path.  Perhaps `Ale` has a way of relaying a general error message in this case.

Regarding the `syntax_check` vs `syntax-check`, `:ALEInfo` gives me:

```
 Current Filetype: perl
Available Linters: ['perl', 'perlcritic', 'syntax-check']
  Enabled Linters: ['syntax-check']
```