### PR TITLE
Add additional diagnostics to error message

### DIFF
--- a/lib/Checker/Impl/Compile.pm
+++ b/lib/Checker/Impl/Compile.pm
@@ -26,6 +26,7 @@ sub check {
         next if grep { $line =~ $_ } @{ $self->{skip} || [] };
         if (my ($m, $f, $l, $e) = $line =~ /^([^\n]+?) at (.+?) line (\d+)(,.*)?/) {
             if ($f eq $tempfile) {
+                $e //= "";
                 push @err, { type => $type, message => "$m$e", line => 0+$l, from => (ref $self) };
             }
         }

--- a/lib/Checker/Impl/Compile.pm
+++ b/lib/Checker/Impl/Compile.pm
@@ -26,7 +26,7 @@ sub check {
         next if grep { $line =~ $_ } @{ $self->{skip} || [] };
         if (my ($m, $f, $l, $e) = $line =~ /^([^\n]+?) at (.+?) line (\d+)(,.*)?/) {
             if ($f eq $tempfile) {
-                $e //= "";
+                $e = "" unless defined $e;
                 push @err, { type => $type, message => "$m$e", line => 0+$l, from => (ref $self) };
             }
         }

--- a/lib/Checker/Impl/Compile.pm
+++ b/lib/Checker/Impl/Compile.pm
@@ -24,9 +24,9 @@ sub check {
     while (my $line = <$fh>) {
         my $type = $line =~ s/^=MarkWarnings=// ? 'WARN' : 'ERROR'; # must s/// before checking skips
         next if grep { $line =~ $_ } @{ $self->{skip} || [] };
-        if (my ($m, $f, $l) = $line =~ /^([^\n]+?) at (.+?) line (\d+)/) {
+        if (my ($m, $f, $l, $e) = $line =~ /^([^\n]+?) at (.+?) line (\d+)(,.*)?/) {
             if ($f eq $tempfile) {
-                push @err, { type => $type, message => $m, line => 0+$l, from => (ref $self) };
+                push @err, { type => $type, message => "$m$e", line => 0+$l, from => (ref $self) };
             }
         }
     }

--- a/t/basic.t
+++ b/t/basic.t
@@ -46,7 +46,7 @@ subtest basic => sub {
 
     @err = $checker->_run("t/file/invalid.pl", "t/file/invalid.pl");
     is @err, 1;
-    is_deeply $err[0], { type => 'ERROR', message => 'syntax error', line => 4, from => 'Checker::Impl::Compile' };
+    is_deeply $err[0], { type => 'ERROR', message => 'syntax error, near "ff', line => 4, from => 'Checker::Impl::Compile' };
 };
 
 subtest skip => sub {


### PR DESCRIPTION
Thanks for writing this!

Some perl errors and warnings provide extra information after the file and line number.  For example:

  Can't use global $0 in "my" at utils/usq line 18, near "= $0 "

This patch will append that extra information, if present, to the main message.  So the message would be:

  Can't use global $0 in "my", near "= $0 "
