### PR TITLE
Allow user to specify arbitrary executable path and script args

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ let g:ale_perl_syntax_check_config = expand('~/.vim/your-config.pl')
 
 " there is also my favorite, and you can use it:)
 let g:ale_perl_syntax_check_config = g:plug_home . '/syntax-check-perl/config/relax.pl'
+
+" add arbitrary perl executable names. defaults to "perl"
+let g:ale_perl_syntax_check_executable = 'my-perl'
 ```
 
 The config files are written in Perl, so you can do whatever you want:) See [default.pl](config/default.pl).

--- a/ale_linters/perl/syntax_check.vim
+++ b/ale_linters/perl/syntax_check.vim
@@ -3,6 +3,9 @@
 "   Author: Vincent Lequertier <https://github.com/SkySymbol>
 "   Description: This file adds support for checking perl syntax
 
+let g:ale_perl_syntax_check_executable =
+\   get(g:, 'ale_perl_syntax_check_executable', 'perl')
+
 let g:ale_perl_syntax_check_config =
 \   get(g:, 'ale_perl_syntax_check_config', g:plug_home . '/syntax-check-perl/config/default.pl')
 
@@ -10,11 +13,16 @@ function! ale_linters#perl#syntax_check#GetConfig(buffer) abort
     return ale#Var(a:buffer, 'perl_syntax_check_config')
 endfunction
 
+function! ale_linters#perl#syntax_check#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'perl_syntax_check_executable')
+endfunction
+
 function! ale_linters#perl#syntax_check#GetCommand(buffer) abort
     let l:config = ale_linters#perl#syntax_check#GetConfig(a:buffer)
     if filereadable(l:config)
-        return g:plug_home . '/syntax-check-perl/syntax-check'
-        \    . ' --config ' . ale#Escape(l:config)
+        return ale#Escape(ale_linters#perl#syntax_check#GetExecutable(a:buffer))
+        \    . ' ' . g:plug_home . '/syntax-check-perl/syntax-check'
+        \    . ' --config ' . ale#Escape(ale_linters#perl#syntax_check#GetConfig(a:buffer))
         \    . ' %s %t'
     else
         echo "[ERROR] ale plugin syntax-check-perl: Couldn't read config file " . l:config
@@ -60,7 +68,7 @@ endfunction
 
 call ale#linter#Define('perl', {
 \   'name': 'syntax-check',
-\   'executable': 'perl',
+\   'executable_callback': 'ale_linters#perl#syntax_check#GetExecutable',
 \   'output_stream': 'both',
 \   'command_callback': 'ale_linters#perl#syntax_check#GetCommand',
 \   'callback': 'ale_linters#perl#syntax_check#Handle',


### PR DESCRIPTION
My $work environment uses a Perl executable to run scripts which is
different from the Perl I (and by extension Ale) use.  This basically
just copies over some of the functionality which Ale's Perl linter
already has.