### PR TITLE
Allow users to override custom Perl libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,18 @@ The config files are written in Perl, so you can do whatever you want. :) See [d
 
 ### Adding libs to @INC
 
-By default we try to add `lib` and `local/lib/perl5` to `@INC` when attempting to compile your code.  Depending on how you work, this may not be what you want.  The good news is that you can manage this via the Perl config file.  See also [default.pl](config/default.pl) for more detailed information on how to do this.
+By default we try to add `lib` and `local/lib/perl5` to `@INC` when attempting
+to compile your code.  Depending on how you work, this may not be what you
+want.  The good news is that you can manage this via the Perl config file.  See
+also [default.pl](config/default.pl) for more detailed information on how to do
+this.
 
 ## Security
 
-You should be aware that we use the `-c` flag to see if `perl` code compiles. This does
-not execute all of the code in a file, but it does run `BEGIN` and `CHECK`
-blocks. See `perl --help` and [StackOverflow](https://stackoverflow.com/a/12908487/406224).
+You should be aware that we use the `-c` flag to see if `perl` code compiles.
+This does not execute all of the code in a file, but it does run `BEGIN` and
+`CHECK` blocks. See `perl --help` and
+[StackOverflow](https://stackoverflow.com/a/12908487/406224).
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ let g:ale_perl_syntax_check_config = g:plug_home . '/syntax-check-perl/config/re
 let g:ale_perl_syntax_check_executable = 'my-perl'
 ```
 
-The config files are written in Perl, so you can do whatever you want:) See [default.pl](config/default.pl).
+The config files are written in Perl, so you can do whatever you want. :) See [default.pl](config/default.pl).
+
+### Adding libs to @INC
+
+By default we try to add `lib` and `local/lib/perl5` to `@INC` when attempting to compile your code.  Depending on how you work, this may not be what you want.  The good news is that you can manage this via the Perl config file.  See also [default.pl](config/default.pl) for more detailed information on how to do this.
+
+## Security
+
+You should be aware that we use the `-c` flag to see if `perl` code compiles. This does
+not execute all of the code in a file, but it does run `BEGIN` and `CHECK`
+blocks. See `perl --help` and [StackOverflow](https://stackoverflow.com/a/12908487/406224).
 
 ## Debugging
 

--- a/config/default.pl
+++ b/config/default.pl
@@ -15,8 +15,8 @@ __END__
     # for `perl -wc` configuration
     compile => {
         inc => {
-            libs    => [ 'lib', 't/lib', 'xt/lib', ],
-            replace => 1,
+            libs                 => [ 'lib', 't/lib', 'xt/lib', ],
+            replace_default_libs => 1,
         },
         skip => [
             qr/^Subroutine \S+ redefined/,
@@ -53,25 +53,31 @@ __END__
 The compile section defines the behaviour under which your code is run via the
 C<-c> flag.
 
-By default, we add C<lib> and C<local/lib/perl5> to C<@INC>.  If you would like to add to these paths, use something like this configuration:
+By default, we add C<lib> and C<local/lib/perl5> to C<@INC>.  If you would like
+to add to these paths, use something like this configuration:
 
   my $config = {
       compile => {
-          inc => ['foo/bar' 'my-custom-lib' ],
-          replace => 0,
+          inc => {
+              libs                 => ['foo/bar' 'my-custom-lib' ],
+              replace_default_libs => 0,
+          },
       },
       ...
   };
 
 This will give you an C<@INC> which includes: C<lib>, C<local/lib/perl>, C<foo/bar> and C<my-custom-lib>
 
-If you would not like the defaults of C<lib> and C<local/lib/perl5> to be added to C<@INC> you can use the C<replace> key:
+If you would not like the defaults of C<lib> and C<local/lib/perl5> to be added
+to C<@INC> you can use the C<replace_default_libs> key:
 
   my $config = {
-      compile => {
-          inc => ['foo/bar' 'my-custom-lib' ],
-          replace => 1,
-      },
+    compile => {
+        inc => {
+            libs                 => [ 'foo/bar' 'my-custom-lib' ],
+            replace_default_libs => 1,
+        },
+    },
       ...
   };
 

--- a/config/default.pl
+++ b/config/default.pl
@@ -14,9 +14,13 @@ __END__
 
     # for `perl -wc` configuration
     compile => {
-      skip => [
-        qr/^Subroutine \S+ redefined/,
-      ],
+        inc => {
+            libs    => [ 'lib', 't/lib', 'xt/lib', ],
+            replace => 1,
+        },
+        skip => [
+            qr/^Subroutine \S+ redefined/,
+        ],
     },
 
     # check line by regexp
@@ -43,5 +47,34 @@ __END__
       ]
     },
   };
+
+=head2 compile
+
+The compile section defines the behaviour under which your code is run via the
+C<-c> flag.
+
+By default, we add C<lib> and C<local/lib/perl5> to C<@INC>.  If you would like to add to these paths, use something like this configuration:
+
+  my $config = {
+      compile => {
+          inc => ['foo/bar' 'my-custom-lib' ],
+          replace => 0,
+      },
+      ...
+  };
+
+This will give you an C<@INC> which includes: C<lib>, C<local/lib/perl>, C<foo/bar> and C<my-custom-lib>
+
+If you would not like the defaults of C<lib> and C<local/lib/perl5> to be added to C<@INC> you can use the C<replace> key:
+
+  my $config = {
+      compile => {
+          inc => ['foo/bar' 'my-custom-lib' ],
+          replace => 1,
+      },
+      ...
+  };
+
+This will give you an C<@INC> which includes: C<foo/bar>, and C<my-custom-lib>
 
 =cut

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,4 @@
 recommends 'JSON::PP';
-requires 'Hash::Merge';
 
 on test => sub {
     requires 'JSON::PP';

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 recommends 'JSON::PP';
+requires 'Hash::Merge';
 
 on test => sub {
     requires 'JSON::PP';

--- a/lib/Checker.pm
+++ b/lib/Checker.pm
@@ -5,7 +5,6 @@ use Cwd ();
 use File::Basename ();
 use File::Spec;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case bundling);
-use Hash::Merge qw( merge );
 
 sub _slurp {
     my $file = shift;
@@ -67,7 +66,9 @@ sub _load_config {
         compile => { inc => { libs => [] } },
     };
 
-    $config = merge( $config, $default_compile );
+    if ( !$config->{compile}{inc}{libs} ) {
+        $config->{compile}{inc}{libs} = [];
+    }
 
     if (  !$config->{compile}{inc}{replace_default_libs}
         && ref $config->{compile}{inc}{libs} eq 'ARRAY' ) {

--- a/lib/Checker.pm
+++ b/lib/Checker.pm
@@ -51,7 +51,7 @@ sub _load_impl {
 
 sub _load_config {
     my ($self, $filename) = @_;
-    my $config;
+    my $config = {};
     if ( $self->{config_file} ) {
         if ( !File::Spec->file_name_is_absolute( $self->{config_file} ) ) {
             $self->{config_file}
@@ -64,12 +64,13 @@ sub _load_config {
     my @default_libs = ( 'lib', 'local/lib/perl5', );
 
     my $default_compile = {
-        compile => { inc => { libs => [], replace => 0 } },
+        compile => { inc => { libs => [] } },
     };
 
     $config = merge( $config, $default_compile );
 
-    if ( !$config->{compile}{inc}{replace} ) {
+    if (  !$config->{compile}{inc}{replace_default_libs}
+        && ref $config->{compile}{inc}{libs} eq 'ARRAY' ) {
         push @{ $config->{compile}{inc}{libs} }, @default_libs;
     }
 

--- a/lib/Checker/Impl/Compile.pm
+++ b/lib/Checker/Impl/Compile.pm
@@ -71,24 +71,21 @@ sub _inc {
     my @relative = grep { !File::Spec->file_name_is_absolute($_) } @inc;
 
     # Find project root directory.
+    LEVEL:
     for (1..10) {
-        last if getcwd eq '/';
+        last LEVEL if getcwd eq '/';
 
+        # Is this the top level directory for the project?
         for my $dir (@relative) {
-
-            # Is this the top level directory for the project?
-            if ( -d $dir ) {
-                @inc = map { abs_path($_) } @inc;
-                last;
-            }
+            last LEVEL if -d $dir;
         }
         chdir '..';
     }
 
-    chdir $back;
-
     # Remove paths which are undefined or do not exist
-    @inc = grep { $_ && -d $_ } @inc;
+    @inc = grep { $_ && -d $_ } map{ abs_path($_) } @inc;
+
+    chdir $back;
     \@inc;
 }
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -130,8 +130,8 @@ subtest custom_config_file => sub {
         {
             compile => {
                 inc => {
-                    libs    => [ 't/lib', 'lib', 'local/lib/perl5', ],
-                    replace => 0,
+                    libs => [ 't/lib', 'lib', 'local/lib/perl5', ],
+                    replace_default_libs => 0,
                 }
             }
         },
@@ -156,8 +156,8 @@ subtest custom_config_file => sub {
     );
 };
 
-subtest custom_config_file_with_replace => sub {
-    local $ENV{REPLACE_LIBS} = 1;
+subtest custom_config_file_with_replace_default_libs => sub {
+    local $ENV{REPLACE_DEFAULT_LIBS} = 1;
     my $checker = Checker->new( config_file => 't/config/custom.pl' );
     $checker->_load_config;
     eq_or_diff(
@@ -165,8 +165,8 @@ subtest custom_config_file_with_replace => sub {
         {
             compile => {
                 inc => {
-                    libs    => [ 't/lib' ],
-                    replace => 1,
+                    libs                 => ['t/lib'],
+                    replace_default_libs => 1,
                 }
             }
         },

--- a/t/config/custom.pl
+++ b/t/config/custom.pl
@@ -3,6 +3,9 @@ use warnings;
 
 return {
     compile => {
-        inc => { libs => ['t/lib'], replace => $ENV{REPLACE_LIBS} ? 1 : 0, }
+        inc => {
+            libs                 => ['t/lib'],
+            replace_default_libs => $ENV{REPLACE_DEFAULT_LIBS} ? 1 : 0,
+        }
     },
 };

--- a/t/config/custom.pl
+++ b/t/config/custom.pl
@@ -3,6 +3,6 @@ use warnings;
 
 return {
     compile => {
-        inc => ['my-lib'],
+        inc => { libs => ['t/lib'], replace => $ENV{REPLACE_LIBS} ? 1 : 0, }
     },
 };

--- a/t/lib/Local.pm
+++ b/t/lib/Local.pm
@@ -1,0 +1,3 @@
+package Local;
+
+1;


### PR DESCRIPTION
Hi @skaji,

I see #9 was already merged.  Here's a pull request to address your comments there.  Note also that the docs have been added to close #4.

The behaviour here is to silently ignore libs which cannot be found rather than warning or just blindly adding them to `@INC`.  Let me know if you'd like this (or other) behaviour changed. :)